### PR TITLE
Catching up elixir v1.0

### DIFF
--- a/08-process-ring.exs
+++ b/08-process-ring.exs
@@ -34,9 +34,9 @@ end
 defmodule Spawner do
   def start do
     limit = 5
-    {foo, _foo_monitor} = Process.spawn_monitor(Pinger, :ping, ["ping", limit])
-    {bar, _bar_monitor} = Process.spawn_monitor(Pinger, :ping, ["pong", limit])
-    {baz, _baz_monitor} = Process.spawn_monitor(Pinger, :ping, ["pung", limit])
+    {foo, _foo_monitor} = spawn_monitor(Pinger, :ping, ["ping", limit])
+    {bar, _bar_monitor} = spawn_monitor(Pinger, :ping, ["pong", limit])
+    {baz, _baz_monitor} = spawn_monitor(Pinger, :ping, ["pung", limit])
     send foo, {[bar, baz, foo], "start", 0}
     wait [foo, bar, baz]
   end

--- a/13-card-deck.exs
+++ b/13-card-deck.exs
@@ -39,7 +39,6 @@ ExUnit.start
 
 defmodule DeckTest do
   use ExUnit.Case
-  doctest Deck
 
   test "new" do
     deck = Deck.new

--- a/14-spades.exs
+++ b/14-spades.exs
@@ -64,8 +64,8 @@ defmodule Dealer do
 
   defp shuffle do
     :random.seed(:erlang.now)
-    deck = lc suit inlist ~w(Hearts Diamonds Clubs Spades),
-              face inlist [2, 3, 4, 5, 6, 7, 8, 9, 10, "J", "Q", "K", "A"],
+    deck = for suit <- ~w(Hearts Diamonds Clubs Spades),
+              face <- [2, 3, 4, 5, 6, 7, 8, 9, 10, "J", "Q", "K", "A"],
               do: {suit, face}
     Enum.shuffle(deck)
   end
@@ -80,7 +80,11 @@ defmodule Dealer do
     Enum.each players, fn p -> send(p, :start) end
   end
 
-  defp wait_for_plays(players, cards_played \\ [], tricks_played \\ 0) when tricks_played < 13 do
+  defp wait_for_plays(players) do
+    wait_for_plays(players, [], 0)
+  end
+
+  defp wait_for_plays(players, cards_played, tricks_played) when tricks_played < 13 do
     if length(cards_played) == 0, do: IO.puts "#{tricks_played} tricks played"
     receive do
       action = {:play, card, player} ->
@@ -214,7 +218,7 @@ defmodule Player do
     try do
       number = IO.gets("Enter a card number to play: ")
         |> String.strip
-        |> binary_to_integer
+        |> String.to_integer
       card = Enum.at(hand, number-1)
       unless card, do: raise ArgumentError
       card
@@ -269,7 +273,7 @@ if List.first(System.argv) == "--test" do
     end
 
     test "setup" do
-      dealer = Process.spawn_monitor Player, :start_game, []
+      dealer = spawn_monitor Player, :start_game, []
       :timer.sleep(100) # TODO why is this necessary?
       two    = spawn Player, :join, []
       three  = spawn Player, :join, []

--- a/15-quine.exs
+++ b/15-quine.exs
@@ -1,4 +1,4 @@
-d= ~S(IO.puts "d= ~S(#{d})"
+d= ~S(IO.puts "d= ~S(#{d}\)"
 IO.puts d)
-IO.puts "d= ~S(#{d})"
+IO.puts "d= ~S(#{d}\)"
 IO.puts d

--- a/16-euler-tree.exs
+++ b/16-euler-tree.exs
@@ -26,13 +26,13 @@ defmodule Tree do
       |> String.split("\n")
       |> Enum.reverse
       |> Enum.map(fn row ->
-        lc num inlist String.split(row, " "), do: binary_to_integer(num)
+        for num <- String.split(row, " "), do: String.to_integer(num)
       end)
       |> Enum.map(fn row -> append_index(row) end)
   end
 
   def reduce_row(row, comparison_row) do
-    lc {{main, index}, {opt1, index1}, {opt2, index2}} inlist pairs(row, comparison_row) do
+    for {{main, index}, {opt1, index1}, {opt2, index2}} <- pairs(row, comparison_row) do
       sum1 = main + opt1
       sum2 = main + opt2
       if sum1 > sum2 do
@@ -44,13 +44,13 @@ defmodule Tree do
   end
 
   def append_index(row) do
-    lc {num, index} inlist Enum.with_index(row) do
+    for {num, index} <- Enum.with_index(row) do
       {num, [index]}
     end
   end
 
   def pairs(row, comparison_row) do
-    lc {num, path = [index | _]} inlist comparison_row do
+    for {num, path = [index | _]} <- comparison_row do
       {{num, path}, Enum.at(row, index), Enum.at(row, index+1)}
     end
   end
@@ -69,7 +69,7 @@ defmodule Tree do
       |> Enum.each(fn {row, row_index} ->
         if rem(row_index, 2) == 0, do: IO.write(" ")
         String.duplicate("  ", div(size - length(row), 2)) |> IO.write
-        (lc {_, [p | _]} inlist row do
+        (for {_, [p | _]} <- row do
           if p == Enum.at(path, row_index) do
             "\e[31mx"
           else

--- a/17-dining-philosophers.exs
+++ b/17-dining-philosophers.exs
@@ -23,7 +23,7 @@ defmodule Table do
 
   h2. Sample Run
 
-    $ elixir 16-dining-philosophers.exs
+    $ elixir 17-dining-philosophers.exs
 
     1 philosopher waiting: Aristotle
     1 philosopher waiting: Kant
@@ -37,18 +37,20 @@ defmodule Table do
     ...
   """
 
-  defrecord Philosopher, name: nil, ate: 0, thunk: 0
+  defmodule Philosopher do
+    defstruct name: nil, ate: 0, thunk: 0
+  end
 
   def simulate do
     forks = [:fork1, :fork2, :fork3, :fork4, :fork5]
 
     table = spawn_link(Table, :manage_resources, [forks])
 
-    spawn(Dine, :dine, [Philosopher[name: "Aristotle"], table])
-    spawn(Dine, :dine, [Philosopher[name: "Kant"     ], table])
-    spawn(Dine, :dine, [Philosopher[name: "Spinoza"  ], table])
-    spawn(Dine, :dine, [Philosopher[name: "Marx"     ], table])
-    spawn(Dine, :dine, [Philosopher[name: "Russell"  ], table])
+    spawn(Dine, :dine, [%Philosopher{name: "Aristotle"}, table])
+    spawn(Dine, :dine, [%Philosopher{name: "Kant"     }, table])
+    spawn(Dine, :dine, [%Philosopher{name: "Spinoza"  }, table])
+    spawn(Dine, :dine, [%Philosopher{name: "Marx"     }, table])
+    spawn(Dine, :dine, [%Philosopher{name: "Russell"  }, table])
 
     receive do: (_ -> :ok)
   end
@@ -89,7 +91,7 @@ defmodule Dine do
   end
 
   def eat(phil, forks, table) do
-    phil = phil.ate(phil.ate + 1)
+    phil = %{phil | ate: phil.ate + 1}
     IO.puts "#{phil.name} is eating (count: #{phil.ate})"
     :timer.sleep(:random.uniform(1000))
     IO.puts "#{phil.name} is done eating"
@@ -100,7 +102,7 @@ defmodule Dine do
   def think(phil, _) do
     IO.puts "#{phil.name} is thinking (count: #{phil.thunk})"
     :timer.sleep(:random.uniform(1000))
-    phil.thunk(phil.thunk + 1)
+    %{phil | thunk: phil.thunk + 1}
   end
 
 end


### PR DESCRIPTION
Hi, it's a very nice set of examples. I'm just trying to update some of the examples for elixir v1.0 (as in #6). 
Basically, it's just update for some deprecation (lc or defrecord), but some specific notes are the following.

- 08-process-ring.exs
    - Process.spawn_monitor is changed to Kernel.spawn_monitor

- 13-card-deck.exs
    - doctest is removed as there seems no doctest is defined.

```
** (ExUnit.DocTest.Error) could not retrieve the documentation for module Deck. The module was not compiled with documentation or its beam file cannot be accessed
    (ex_unit) lib/ex_unit/doc_test.ex:345: ExUnit.DocTest.extract/1
    (ex_unit) lib/ex_unit/doc_test.ex:168: ExUnit.DocTest.__doctests__/2
    13-card-deck.exs:42: (module)
```

- 14-spades.exs
    - separate function with both default value and guard.
      (wait_for_plays/2 is originally defined, but not added as it's not used for avoiding warning)

```
** (CompileError) 14-spades.exs:102: defp wait_for_plays/3 has default values and multiple clauses, define a function head with the defaults
    (elixir) src/elixir_def.erl:328: :elixir_def.store_each/7
    (elixir) src/elixir_def.erl:91: :elixir_def.store_definition/9
    14-spades.exs:102: (module)
    14-spades.exs:27: (file)
```

- 15-quine.exs
    - Escaped closing `)` for avoiding compile error (couldn't find the exact reason, but assume it's some behavioral change in sigil).

```
** (TokenMissingError) 15-quine.exs:5: missing terminator: " (for string starting at line 3)
    (elixir) lib/code.ex:316: Code.require_file/2
```
