### PR TITLE
KeyError is raised instead of ArgumentError for updating map with pattern matching syntax

### DIFF
--- a/05-dict-and-map.exs
+++ b/05-dict-and-map.exs
@@ -42,7 +42,7 @@ defmodule MapTest do
     # You can only update existing keys in this way
     assert %{sample | foo: 'bob'} == %{foo: 'bob', baz: 'quz'}
     # It doesn't work if you want to add new keys
-    assert_raise ArgumentError, fn ->
+    assert_raise KeyError, fn ->
       %{sample | far: 'bob'}
     end
   end


### PR DESCRIPTION
``` bash
$ elixir -v
Elixir 1.0.5
$ erl -v
Erlang/OTP 18 [erts-7.0.3]
```