### PR TITLE
Remove speed test for map and dict

### DIFF
--- a/05-map.exs
+++ b/05-map.exs
@@ -1,4 +1,3 @@
-# http://elixir-lang.org/docs/stable/elixir/Dict.html
 # http://elixir-lang.org/docs/stable/elixir/Map.html
 
 ExUnit.start
@@ -50,31 +49,6 @@ defmodule MapTest do
   test "Map.values" do
     # Map does not preserve order of keys, thus we Enum.sort
     assert Enum.sort(Map.values(sample)) == ['bar', 'quz']
-  end
-end
-
-
-defmodule SpeedTest do
-  use ExUnit.Case
-
-  # HashDict is fast (9038 microsecs)
-  test "HashDict speed" do
-    {microsec, _} = :timer.tc fn ->
-      Enum.reduce 1..10_000, HashDict.new, fn (i, d) ->
-        Dict.put d, i, 'foo'
-      end
-    end
-    IO.puts "HashDict took #{microsec} microsecs"
-  end
-
-  # Map is slower?? (405888 microsecs)
-  test "Map speed" do
-    {microsec, _} = :timer.tc fn ->
-      Enum.reduce 1..10_000, Map.new, fn (i, d) ->
-        Map.put d, i, 'foo'
-      end
-    end
-    IO.puts "Map took #{microsec} microsecs"
   end
 end
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A walk through the [Elixir](http://elixir-lang.org/) language, one exercise per 
 
 **04-list.exs** - What's a functional language without a List? Here we learn some simple list manipulation, and for awhile we can pretend lists are like our familiar Ruby arrays. :-)
 
-**05-dict.exs** - Dict and Keyword structures are a bit of a departure from the Hash in Ruby world. Sure, it's an associative array, but wrapping our minds around Keyword vs HashDict vs ListDict can be confusing. Luckily, it seems we can simplify by defaulting to [HashDict.new](http://elixir-lang.org/docs/stable/elixir/HashDict.html#new/0) and using the [Dict methods](http://elixir-lang.org/docs/stable/elixir/Dict.html) for manipulation.
+**05-map.exs** - A Dict implementation that works en maps. For more information about the functions in this module and their APIs, please consult the Dict module.
 
 **06-record.exs** - Where are our beloved objects? In functional programming, data is just data, and Elixir gives you the Record structure to organize it a bit. Records are a little like Struct from other imperative languages, except of course they are immutable!
 


### PR DESCRIPTION
I run the speed test about 10 times, and every time `Map` runs faster than `HashDict`. I think it's better to remove this speed comparison is incorrect and misleading.