### PR TITLE
remove unreachable clause

### DIFF
--- a/08-process-ring.exs
+++ b/08-process-ring.exs
@@ -25,9 +25,6 @@ defmodule Pinger do
       # someone told us to stop, so pass along the message
       {[next | rest], :ok} ->
         send next, {rest, :ok}
-
-      # done!
-      {[], :ok} -> :ok
     end
   end
 end


### PR DESCRIPTION
This clause is sent by the "tail" node on the ring to the "head" node. However, by the time this message is sent, the "tail" node has long gone. Thus, this clause is never matched.

Side note: <code> send(pid, "a message") </code> doesn't fail even if the pid is no longer alive.