### PR TITLE
Fix incorrect assertion on map test

### DIFF
--- a/05-map.exs
+++ b/05-map.exs
@@ -41,7 +41,7 @@ defmodule MapTest do
     # You can only update existing keys in this way
     assert %{sample | foo: 'bob'} == %{foo: 'bob', baz: 'quz'}
     # It doesn't work if you want to add new keys
-    assert_raise ArgumentError, fn ->
+    assert_raise KeyError, fn ->
       %{sample | far: 'bob'}
     end
   end


### PR DESCRIPTION
KeyError is raised instead of an ArgumentError when trying to use
pattern matching to update a map key that doesn't exist.