### PR TITLE
Update soon to be deprecated String method

### DIFF
--- a/03-input-output.exs
+++ b/03-input-output.exs
@@ -11,7 +11,7 @@ defmodule CowInterrogator do
   """
   def get_name do
     IO.gets("What is your name? ")
-    |> String.strip
+    |> String.trim
   end
 
   def get_cow_lover do
@@ -50,7 +50,7 @@ defmodule InputOutputTest do
   test "checks if cow_art returns string from support/cow.txt" do
     # this call checks if cow_art function returns art from txt file
     art = CowInterrogator.cow_art
-    assert strip(art) |> first == "(" # first is implemented in String module
+    assert trim(art) |> first == "(" # first is implemented in String module
   end
 end
 


### PR DESCRIPTION
String.strip is being soft deprecated in favour of String.trim because of the confusing name
https://github.com/elixir-lang/elixir/blob/v1.3/CHANGELOG.md#3-soft-deprecations-no-warnings-emitted