### PR TITLE
Update links and resolve warnings

### DIFF
--- a/03-input-output.exs
+++ b/03-input-output.exs
@@ -1,5 +1,5 @@
-# http://elixir-lang.org/docs/stable/elixir/IO.html
-# http://elixir-lang.org/docs/stable/elixir/File.html
+# https://hexdocs.pm/elixir/IO.html
+# https://hexdocs.pm/elixir/File.html
 
 defmodule CowInterrogator do
 
@@ -19,11 +19,11 @@ defmodule CowInterrogator do
   end
 
   def interrogate do
-    name = get_name
-    case String.downcase(get_cow_lover) do
+    name = get_name()
+    case String.downcase(get_cow_lover()) do
       "y" ->
         IO.puts "Great! Here's a cow for you #{name}:"
-        IO.puts cow_art
+        IO.puts cow_art()
       "n" ->
         IO.puts "That's a shame, #{name}."
       _ ->


### PR DESCRIPTION
The documentation links are returning 404.
Invoking the functions without the parenthesis results in a console warning:
```
$ elixir 03-input-output.exs
warning: variable "get_name" does not exist and is being expanded to "get_name()", please use parentheses to remove the ambiguity or change the variable name
  03-input-output.exs:22

warning: variable "get_cow_lover" does not exist and is being expanded to "get_cow_lover()", please use parentheses to remove the ambiguity or change the variable name
  03-input-output.exs:23

warning: variable "cow_art" does not exist and is being expanded to "cow_art()", please use parentheses to remove the ambiguity or change the variable name
  03-input-output.exs:26
```