### PR TITLE
Update doc link and fix deprecated syntax

### DIFF
--- a/05-map.exs
+++ b/05-map.exs
@@ -1,4 +1,4 @@
-# http://elixir-lang.org/docs/stable/elixir/Map.html
+# https://hexdocs.pm/elixir/Map.html
 
 ExUnit.start
 
@@ -10,45 +10,45 @@ defmodule MapTest do
   end
 
   test "Map.get" do
-    assert Map.get(sample, :foo) == 'bar'
-    assert Map.get(sample, :non_existent) == nil
+    assert Map.get(sample(), :foo) == 'bar'
+    assert Map.get(sample(), :non_existent) == nil
   end
 
   test "[]" do
-    assert sample[:foo] == 'bar'
-    assert sample[:non_existent] == nil
+    assert sample()[:foo] == 'bar'
+    assert sample()[:non_existent] == nil
   end
 
   test "." do
-    assert sample.foo == 'bar'
+    assert sample().foo == 'bar'
     assert_raise KeyError, fn ->
-      sample.non_existent
+      sample().non_existent
     end
   end
 
   test "Map.fetch" do
-    {:ok, val} = Map.fetch(sample, :foo)
+    {:ok, val} = Map.fetch(sample(), :foo)
     assert val == 'bar'
-    :error = Map.fetch(sample, :non_existent)
+    :error = Map.fetch(sample(), :non_existent)
   end
 
   test "Map.put" do
-    assert Map.put(sample, :foo, 'bob') == %{foo: 'bob', baz: 'quz'}
-    assert Map.put(sample, :far, 'bar') == %{foo: 'bar', baz: 'quz', far: 'bar'}
+    assert Map.put(sample(), :foo, 'bob') == %{foo: 'bob', baz: 'quz'}
+    assert Map.put(sample(), :far, 'bar') == %{foo: 'bar', baz: 'quz', far: 'bar'}
   end
 
   test "Update map using pattern matching syntax" do
     # You can only update existing keys in this way
-    assert %{sample | foo: 'bob'} == %{foo: 'bob', baz: 'quz'}
+    assert %{ sample() | foo: 'bob'} == %{foo: 'bob', baz: 'quz'}
     # It doesn't work if you want to add new keys
     assert_raise KeyError, fn ->
-      %{sample | far: 'bob'}
+      %{ sample() | far: 'bob'}
     end
   end
 
   test "Map.values" do
     # Map does not preserve order of keys, thus we Enum.sort
-    assert Enum.sort(Map.values(sample)) == ['bar', 'quz']
+    assert Enum.sort(Map.values(sample())) == ['bar', 'quz']
   end
 end
 


### PR DESCRIPTION
Documentation link for Map was returning 404.

ℹ️ Another way of doing this would be to delete the sample function, declare a module attribute `@sample %{foo: 'bar', baz: 'quz'}`, and then use `@sample` instead of `sample()` in the code below. Feel free to reject this PR depending on your personal preferences.